### PR TITLE
Update domain name CHipCie website

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ If you have any questions, please [contact us](/contact).
 
 - [BAPC problems](/bapc/problems.pdf)
 - [BAPC solutions](/bapc/solutions.pdf)
-- [BAPC testdata and solutions (47MB)](https://commissies.ch.tudelft.nl/chipcie/archive/2022/bapc/solutions.zip)
+- [BAPC testdata and solutions (47MB)](https://chipcie.wisv.ch/archive/2022/bapc/solutions.zip)
 - [BAPC scoreboard](/bapc/scoreboard/)
 - [BAPC stream](https://www.youtube.com/watch?v=GFHSwV8pFe0)
 - [BAPC closing ceremony stream](https://www.youtube.com/watch?v=flna2TmINHc)
@@ -19,5 +19,5 @@ If you have any questions, please [contact us](/contact).
 
 - [Preliminaries problems](/preliminaries/problems.pdf)
 - [Preliminaries solutions](/preliminaries/solutions.pdf)
-- [Preliminaries testdata and solutions (115MB)](https://commissies.ch.tudelft.nl/chipcie/archive/2022/dapc/solutions.zip)
+- [Preliminaries testdata and solutions (115MB)](https://chipcie.wisv.ch/archive/2022/dapc/solutions.zip)
 - [Preliminaries scoreboard](/preliminaries/scoreboard/)


### PR DESCRIPTION
The CHipCie website has changed domain name and this fix it when the old site is removed.